### PR TITLE
Easy to use Inference code 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pretrained_models
 ./*.mp4
 demo/tmp
 demo/outputs
+.venv

--- a/inference.py
+++ b/inference.py
@@ -1,3 +1,4 @@
+import argparse
 import numpy as np
 from PIL import Image
 import imageio
@@ -6,32 +7,29 @@ from demo.animate import MagicAnimate
 
 def read_video(video_path):
     reader = imageio.get_reader(video_path)
-    # You might want to process the video frames here
     return video_path
 
 def read_image(image_path, size=512):
     image = Image.open(image_path)
     return np.array(image.resize((size, size)))
 
-def main(reference_image, motion_sequence, seed, steps, guidance_scale):
+def main(reference_image_path, motion_sequence_path, seed, steps, guidance_scale):
     animator = MagicAnimate()
 
-    animation = animator(reference_image, motion_sequence, seed, steps, guidance_scale)
+    reference_image = read_image(reference_image_path)
+    motion_sequence = read_video(motion_sequence_path)
 
-    # Assuming the output is in a format that can be saved with imageio
-    # imageio.mimsave('output_animation.mp4', animation)
+    animation = animator(reference_image, motion_sequence, seed, steps, guidance_scale)
     return animation
 
-# Set your values here
-reference_image_path = "/home/bilal/magic-animate/inputs/applications/source_image/multi1_source.png"
-motion_sequence_path = "/home/bilal/magic-animate/inputs/applications/driving/densepose/multi_dancing.mp4"
-seed = 1
-steps = 25
-guidance_scale = 7.5
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Animate images using MagicAnimate.")
+    parser.add_argument("reference_image", help="Path to the reference image")
+    parser.add_argument("motion_sequence", help="Path to the motion sequence video")
+    parser.add_argument("--seed", type=int, default=1, help="Random seed (default: 1)")
+    parser.add_argument("--steps", type=int, default=25, help="Sampling steps (default: 25)")
+    parser.add_argument("--guidance_scale", type=float, default=7.5, help="Guidance scale (default: 7.5)")
 
-# Read the image and video
-reference_image = read_image(reference_image_path)
-motion_sequence = read_video(motion_sequence_path)
+    args = parser.parse_args()
 
-# Run the main function
-main(reference_image, motion_sequence, seed, steps, guidance_scale)
+    main(args.reference_image, args.motion_sequence, args.seed, args.steps, args.guidance_scale)

--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,37 @@
+import numpy as np
+from PIL import Image
+import imageio
+
+from demo.animate import MagicAnimate
+
+def read_video(video_path):
+    reader = imageio.get_reader(video_path)
+    # You might want to process the video frames here
+    return video_path
+
+def read_image(image_path, size=512):
+    image = Image.open(image_path)
+    return np.array(image.resize((size, size)))
+
+def main(reference_image, motion_sequence, seed, steps, guidance_scale):
+    animator = MagicAnimate()
+
+    animation = animator(reference_image, motion_sequence, seed, steps, guidance_scale)
+
+    # Assuming the output is in a format that can be saved with imageio
+    # imageio.mimsave('output_animation.mp4', animation)
+    return animation
+
+# Set your values here
+reference_image_path = "/home/bilal/magic-animate/inputs/applications/source_image/multi1_source.png"
+motion_sequence_path = "/home/bilal/magic-animate/inputs/applications/driving/densepose/multi_dancing.mp4"
+seed = 1
+steps = 25
+guidance_scale = 7.5
+
+# Read the image and video
+reference_image = read_image(reference_image_path)
+motion_sequence = read_video(motion_sequence_path)
+
+# Run the main function
+main(reference_image, motion_sequence, seed, steps, guidance_scale)


### PR DESCRIPTION
This pull requests contains easy to use inference code. The shell script provided by authors for inferecing doesn't save video files. Also for generating videos on custom images one has to rewrite the .yaml file. 

The script can be run by using
```
python script_name.py path_to_reference_image.jpg path_to_motion_sequence.mp4 --seed 123 --steps 50 --guidance_scale 5.0
```